### PR TITLE
Add 'request' dependency, plus a deprecation comment.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "token.js",
   "dependencies": {
-    "puppeteer": "^0.13.0"
+    "puppeteer": "^0.13.0",
+    "request": "^2.88.2"
   },
   "devDependencies": {},
   "scripts": {

--- a/src/player.js
+++ b/src/player.js
@@ -1,3 +1,4 @@
+// Note that 'request' is deprecated: https://github.com/request/request/issues/3142
 var request = require('request');
 var tokenValidator = require('./tokenValidator');
 const


### PR DESCRIPTION
Fixes missing dependency; see also issue #1.